### PR TITLE
Fixed tabs on example page

### DIFF
--- a/docs/examples/tournaments-by-location.md
+++ b/docs/examples/tournaments-by-location.md
@@ -10,11 +10,11 @@ In these examples, we will query for tournaments in a given location!
 ```
 query TournamentsByCountry($cCode: String!, $perPage: Int) {
     tournaments(query: {
-    	perPage: $perPage
-    	filter: {
-      	countryCode: $cCode
-    	}
-  	}) {
+      perPage: $perPage
+      filter: {
+        countryCode: $cCode
+      }
+    }) {
     nodes {
       id
       name

--- a/docs/examples/tournaments-by-location.md
+++ b/docs/examples/tournaments-by-location.md
@@ -72,9 +72,9 @@ Request Variables
 ```
 query TournamentsByState($perPage: Int, $state: String!) {
     tournaments(query: {
-    	perPage: $perPage
+      perPage: $perPage
       filter: {
-      addrState: $state
+        addrState: $state
     }
   }) {
     nodes {
@@ -134,13 +134,13 @@ Request Variables
 ```
 query SocalTournaments($perPage: Int, $coordinates: String!, $radius: String!) {
     tournaments(query: {
-    	perPage: $perPage
+      perPage: $perPage
       filter: {
-      location: {
-        distanceFrom: $coordinates,
-        distance: $radius
+        location: {
+          distanceFrom: $coordinates,
+          distance: $radius
+        }
       }
-    }
   }) {
     nodes {
       id


### PR DESCRIPTION
https://trello.com/c/3BE4jNVQ/17-indentation-in-all-3-example-queries-on-https-developersmashgg-docs-examples-tournaments-by-location-are-slightly-off

Fixes the tab issues in the example file