### PR TITLE
Minor tab cleanup on some docs.

### DIFF
--- a/docs/examples/count-entrants-by-event.md
+++ b/docs/examples/count-entrants-by-event.md
@@ -19,7 +19,7 @@ query EventStandings($eventId: Int) {
     id
     name
     numEntrants
-	entrantSizeMin
+    entrantSizeMin
   }
 }
 ```
@@ -54,7 +54,7 @@ query EventStandings($eventId: Int) {
     id
     name
     numEntrants
-	entrantSizeMin
+    entrantSizeMin
   }
 }
 ```

--- a/docs/examples/tournaments-by-location.md
+++ b/docs/examples/tournaments-by-location.md
@@ -9,12 +9,12 @@ In these examples, we will query for tournaments in a given location!
 
 ```
 query TournamentsByCountry($cCode: String!, $perPage: Int) {
-    tournaments(query: {
-      perPage: $perPage
-      filter: {
-        countryCode: $cCode
-      }
-    }) {
+  tournaments(query: {
+    perPage: $perPage
+    filter: {
+      countryCode: $cCode
+    }
+  }) {
     nodes {
       id
       name
@@ -71,10 +71,10 @@ Request Variables
 
 ```
 query TournamentsByState($perPage: Int, $state: String!) {
-    tournaments(query: {
-      perPage: $perPage
-      filter: {
-        addrState: $state
+  tournaments(query: {
+    perPage: $perPage
+    filter: {
+      addrState: $state
     }
   }) {
     nodes {
@@ -133,14 +133,14 @@ Request Variables
 
 ```
 query SocalTournaments($perPage: Int, $coordinates: String!, $radius: String!) {
-    tournaments(query: {
-      perPage: $perPage
-      filter: {
-        location: {
-          distanceFrom: $coordinates,
-          distance: $radius
-        }
+  tournaments(query: {
+    perPage: $perPage
+    filter: {
+      location: {
+        distanceFrom: $coordinates,
+        distance: $radius
       }
+    }
   }) {
     nodes {
       id

--- a/docs/examples/tournaments-by-videogame.md
+++ b/docs/examples/tournaments-by-videogame.md
@@ -14,17 +14,17 @@ For now, you can view the mapping of videogame IDs to their names <a href="https
 
 ```
 query TournamentsByVideogame($perPage: Int, $videogameId: Int) {
-    tournaments(query: {
-        perPage: $perPage
-      	page: 1
-      	sortBy: "startAt asc"
-        filter: {
-          past: false
-        	videogameIds: [
-            $videogameId
-          ]
-        }
-    }) {
+  tournaments(query: {
+    perPage: $perPage
+    page: 1
+    sortBy: "startAt asc"
+    filter: {
+      past: false
+      videogameIds: [
+        $videogameId
+      ]
+    }
+  }) {
     nodes {
       id
       name
@@ -76,15 +76,15 @@ Query Variables
 
 ```
 query TournamentsByVideogames($perPage: Int, $videogameIds: [Int]) {
-    tournaments(query: {
-        perPage: $perPage
-      	page: 1
-      	sortBy: "startAt asc"
-        filter: {
-          upcoming: true
-        	videogameIds: $videogameIds
-        }
-    }) {
+  tournaments(query: {
+    perPage: $perPage
+    page: 1
+    sortBy: "startAt asc"
+    filter: {
+      upcoming: true
+      videogameIds: $videogameIds
+    }
+  }) {
     nodes {
       id
       name


### PR DESCRIPTION
This PR makes some minor changes to tabbing on some queries in the docs, namely within `count-entrants-by-event.md`, `tournaments-by-location.md`, and `tournaments-by-videogame.md`.