### PR TITLE
declare graphql for the fenced query blocks

### DIFF
--- a/docs/benefits-of-gql.md
+++ b/docs/benefits-of-gql.md
@@ -19,7 +19,7 @@ If you want the name of each event, and the placement + names of the top 3 finis
 
 ## Example Request
 
-```
+```graphql
 query TournamentQuery($slug: String, $page: Int, $perPage: Int) {
         tournament(slug: $slug){
             events {

--- a/docs/examples/attendees-by-sponsor.md
+++ b/docs/examples/attendees-by-sponsor.md
@@ -8,7 +8,7 @@ In this case, we've chosen Genesis 5 as the tournament and Cloud 9 as the sponso
 
 ## Example Request
 
-```
+```graphql
 query PrefixSearchAttendees($tourneySlug:String!, $sponsor: String!) {
   tournament(slug: $tourneySlug) {
     id

--- a/docs/examples/count-entrants-by-event.md
+++ b/docs/examples/count-entrants-by-event.md
@@ -13,7 +13,7 @@ You can also use that number to count the total number of players who competed i
 
 ## Example #1 Request (3v3 Teams Event)
 
-```
+```graphql
 query EventStandings($eventId: Int) {
   event(id:$eventId) {
     id
@@ -48,7 +48,7 @@ Request Variables
 
 ## Example #2 Request (1v1 Event)
 
-```
+```graphql
 query EventStandings($eventId: Int) {
   event(id:$eventId) {
     id

--- a/docs/examples/event-standings.md
+++ b/docs/examples/event-standings.md
@@ -9,7 +9,7 @@ and **name** of the **top 3 placements** (note the variables!)
 
 ## Example #1 Request (basic)
 
-```
+```graphql
 query EventStandings($eventId: Int, $page: Int, $perPage: Int) {
   event(id: $eventId) {
     name
@@ -84,7 +84,7 @@ You can choose your own names for these variables! In the query above...
 
 ## Example #2 Request (Race Format)
 
-```
+```graphql
 query EventStandings($eventId: Int) {
   event(id:$eventId) {
     id

--- a/docs/examples/pool-seeds.md
+++ b/docs/examples/pool-seeds.md
@@ -9,7 +9,7 @@ We'll include the name, and the seed id, of each entrant.
 
 ## Example Request
 
-```
+```graphql
 query PoolSeeds($phaseGroupId: Int) {
   phaseGroup(id: $phaseGroupId) {
     seeds {

--- a/docs/examples/set-entrants.md
+++ b/docs/examples/set-entrants.md
@@ -10,7 +10,7 @@ so we will get the available fields for each of those, too!
 
 ## Example Request
 
-```
+```graphql
 query SetEntrants($setId: String!) {
   set(id: $setId) {
     id

--- a/docs/examples/tournaments-by-location.md
+++ b/docs/examples/tournaments-by-location.md
@@ -7,7 +7,7 @@ In these examples, we will query for tournaments in a given location!
 
 ## Example #1 Request (by Country)
 
-```
+```graphql
 query TournamentsByCountry($cCode: String!, $perPage: Int) {
   tournaments(query: {
     perPage: $perPage
@@ -69,7 +69,7 @@ Request Variables
 
 ## Example #2 Request (by State)
 
-```
+```graphql
 query TournamentsByState($perPage: Int, $state: String!) {
   tournaments(query: {
     perPage: $perPage
@@ -131,7 +131,7 @@ Request Variables
 
 ## Example #3 Request (by coordinates + radius distance)
 
-```
+```graphql
 query SocalTournaments($perPage: Int, $coordinates: String!, $radius: String!) {
   tournaments(query: {
     perPage: $perPage

--- a/docs/examples/tournaments-by-owner.md
+++ b/docs/examples/tournaments-by-owner.md
@@ -9,7 +9,7 @@ It will only return tournaments which that user created.
 
 ## Example #1 Request
 
-```json
+```graphql
 query TournamentsByowner($perPage: Int, $ownerId: Int) {
     tournaments(query: {
       perPage: $perPage

--- a/docs/examples/tournaments-by-videogame.md
+++ b/docs/examples/tournaments-by-videogame.md
@@ -12,7 +12,7 @@ For now, you can view the mapping of videogame IDs to their names <a href="https
 
 ## Example #1 Request (single videogame)
 
-```
+```graphql
 query TournamentsByVideogame($perPage: Int, $videogameId: Int) {
   tournaments(query: {
     perPage: $perPage
@@ -74,7 +74,7 @@ Query Variables
 
 ## Example #2 Request (array of videogames)
 
-```
+```graphql
 query TournamentsByVideogames($perPage: Int, $videogameIds: [Int]) {
   tournaments(query: {
     perPage: $perPage


### PR DESCRIPTION
Didn't realize GraphQL was supported as a language to declare for fenced code blocks in Markdown. Awesome! Went ahead and applied that to the fenced blocks for requests in each example doc.