### PR TITLE
Refactored Example Queries w/ Code Tabs

### DIFF
--- a/docs/benefits-of-gql.md
+++ b/docs/benefits-of-gql.md
@@ -20,7 +20,7 @@ If you want the name of each event, and the placement + names of the top 3 finis
 ## Example Request
 
 ```graphql
-query TournamentQuery($slug: String, $page: Int, $perPage: Int) {
+query TournamentQuery($slug: String, $page: Int!, $perPage: Int!) {
         tournament(slug: $slug){
             events {
               name

--- a/docs/examples/attendee-counts.md
+++ b/docs/examples/attendee-counts.md
@@ -7,7 +7,11 @@ In this example, we will query for the number of attendees (participants) in a t
 Optionally, we can include an array of eventIds to specify a count for a particular subset of events
  in that tournament.
 
-## Example #1 Request
+## Example #1
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Request-->
+
 ```GraphQL
 query AttendeeCount($tourneySlug:String!){
   tournament(slug:$tourneySlug){
@@ -18,18 +22,15 @@ query AttendeeCount($tourneySlug:String!){
       }
     }
   }
-}
-```
-
-Request Variables
-```GraphQl
+},
 {
   "tourneySlug":"shine-2018"
 }
 ```
 
-## Example #1 Response
-```GraphQL
+<!--Response-->
+
+```json
 {
   "data": {
     "tournament": {
@@ -44,8 +45,12 @@ Request Variables
   "actionRecords": []
 }
 ```
+<!--END_DOCUSAURUS_CODE_TABS-->
 
-## Example #2 Request (specifying event(s))
+## Example #2 (specifying event(s))
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Request-->
 
 ```GraphQL
 query AttendeeCount($tourneySlug:String!, $eventIds:[Int]){
@@ -61,19 +66,15 @@ query AttendeeCount($tourneySlug:String!, $eventIds:[Int]){
       }
     }
   }
-}
-```
-
-Request Variables
-```GraphQL
+},
 {
   "tourneySlug":"shine-2018",
   "eventIds":[78790]
 }
 ```
+<!--Response-->
 
-## Example #2 Response
-```GraphQL
+```json
 {
   "data": {
     "tournament": {
@@ -88,3 +89,5 @@ Request Variables
   "actionRecords": []
 }
 ```
+
+<!--END_DOCUSAURUS_CODE_TABS-->

--- a/docs/examples/attendees-by-sponsor.md
+++ b/docs/examples/attendees-by-sponsor.md
@@ -6,7 +6,11 @@ title: Attendees by Sponsor/Org
 In this example, we will query for the attendees of a tournament with a particular sponsor tag.
 In this case, we've chosen Genesis 5 as the tournament and Cloud 9 as the sponsor/org.
 
-## Example Request
+## Example
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--Request-->
 
 ```graphql
 query PrefixSearchAttendees($tourneySlug:String!, $sponsor: String!) {
@@ -27,19 +31,14 @@ query PrefixSearchAttendees($tourneySlug:String!, $sponsor: String!) {
       }
     }
   }
-}
-```
-
-Request Variables
-
-```json
+},
 {
   "tourneySlug": "genesis-5",
   "sponsor": "c9"
 }
 ```
 
-## Example Response
+<!--Response-->
 
 ```json
 {
@@ -68,3 +67,5 @@ Request Variables
   "actionRecords": []
 }
 ```
+
+<!--END_DOCUSAURUS_CODE_TABS-->

--- a/docs/examples/count-entrants-by-event.md
+++ b/docs/examples/count-entrants-by-event.md
@@ -11,27 +11,26 @@ or a teams event (`entrantSizeMin` > 1).
 You can also use that number to count the total number of players who competed in a teams event
 (with some variance due to substitute players).
 
-## Example #1 Request (3v3 Teams Event)
+## Example #1 (3v3 Teams Event)
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Request-->
 
 ```graphql
-query EventStandings($eventId: Int) {
+query CountEntrants($eventId: Int!) {
   event(id:$eventId) {
     id
     name
     numEntrants
     entrantSizeMin
   }
-}
-```
-
-Request Variables
-```
+},
 {
   "eventId": 29368
 }
 ```
 
-## Example #1 Response
+<!--Response-->
 
 ```json
 {
@@ -46,28 +45,28 @@ Request Variables
 }
 ```
 
-## Example #2 Request (1v1 Event)
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+## Example #2 (1v1 Event)
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Request-->
 
 ```graphql
-query EventStandings($eventId: Int) {
+query CountEntrants($eventId: Int!) {
   event(id:$eventId) {
     id
     name
     numEntrants
     entrantSizeMin
   }
-}
-```
-
-Request Variables
-
-```json
+},
 {
   "eventId": 78790
 }
 ```
 
-## Example #2 Response
+<!--Response-->
 
 ```json
 {
@@ -82,3 +81,5 @@ Request Variables
   "actionRecords": []
 }
 ```
+
+<!--END_DOCUSAURUS_CODE_TABS-->

--- a/docs/examples/event-standings.md
+++ b/docs/examples/event-standings.md
@@ -13,7 +13,7 @@ and **name** of the **top 3 placements** (note the variables!)
 <!--Request-->
 
 ```graphql
-query EventStandings($eventId: Int, $page: Int, $perPage: Int) {
+query EventStandings($eventId: Int!, $page: Int!, $perPage: Int!) {
   event(id: $eventId) {
     name
     standings(query: {
@@ -91,7 +91,7 @@ If you don't know what race format is, then don't worry about this!
 <!--Request-->
 
 ```graphql
-query EventStandings($eventId: Int) {
+query EventStandings($eventId: Int!) {
   event(id:$eventId) {
     id
     name

--- a/docs/examples/event-standings.md
+++ b/docs/examples/event-standings.md
@@ -7,7 +7,10 @@ In this example, we will query for the standings of the Melee Singles event at S
 To be specific, we will query for just the **standing**
 and **name** of the **top 3 placements** (note the variables!)
 
-## Example #1 Request (basic)
+## Example #1 (basic)
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Request-->
 
 ```graphql
 query EventStandings($eventId: Int, $page: Int, $perPage: Int) {
@@ -25,12 +28,7 @@ query EventStandings($eventId: Int, $page: Int, $perPage: Int) {
       }
     }
   }
-}
-```
-
-Request Variables 
-
-```json
+},
 {
   "eventId": 78790,
   "page": 1,
@@ -38,15 +36,7 @@ Request Variables
 }
 ```
 
-You can choose your own names for these variables! In the query above...
-
-- *eventId* is the ID of the event we're getting standings for
-- *page* is the page of standings we have specified to retrieve (page 1 starts with 1st place)
-- *perPage* is the number of standings we are retrieving on that page
-
-**Don't forget to explore the schema in the graphiql explorer!**
-
-## Example #1 Response
+<!--Response-->
 
 ```json
 {
@@ -82,7 +72,23 @@ You can choose your own names for these variables! In the query above...
 }
 ```
 
-## Example #2 Request (Race Format)
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+You can choose your own names for these variables! In the query above...
+
+- *eventId* is the ID of the event we're getting standings for
+- *page* is the page of standings we have specified to retrieve (page 1 starts with 1st place)
+- *perPage* is the number of standings we are retrieving on that page
+
+**Don't forget to explore schema, and test queries, in the [API Explorer](/explorer)!**
+
+## Example #2 (Race Format)
+
+Race format is a bit of an exception to standings queries at the moment.
+If you don't know what race format is, then don't worry about this!
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Request-->
 
 ```graphql
 query EventStandings($eventId: Int) {
@@ -100,18 +106,13 @@ query EventStandings($eventId: Int) {
       }
     }
   }
-}
-```
-
-Request Variables
-
-```json
+},
 {
   "eventId": 249917
 }
 ```
 
-## Example #2 Response
+<!--Response-->
 
 ```json
 {
@@ -151,3 +152,5 @@ Request Variables
   "actionRecords": []
 }
 ```
+
+<!--END_DOCUSAURUS_CODE_TABS-->

--- a/docs/examples/pool-seeds.md
+++ b/docs/examples/pool-seeds.md
@@ -7,7 +7,10 @@ In this example, we will query for the seeding of a phase group (a pool)
 in the Rivals of Aether Singles event at Genesis 5.
 We'll include the name, and the seed id, of each entrant. 
 
-## Example Request
+## Example
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Request-->
 
 ```graphql
 query PoolSeeds($phaseGroupId: Int) {
@@ -19,18 +22,13 @@ query PoolSeeds($phaseGroupId: Int) {
       }
     }
   }
-}
-```
-
-Request Variables
-
-```json
+},
 {
   "phaseGroupId": "398727"
 }
 ```
 
-## Example Response
+<!--Response-->
 
 ```json
 {
@@ -157,3 +155,5 @@ Request Variables
   "actionRecords": []
 }
 ```
+
+<!--END_DOCUSAURUS_CODE_TABS-->

--- a/docs/examples/pool-seeds.md
+++ b/docs/examples/pool-seeds.md
@@ -13,7 +13,7 @@ We'll include the name, and the seed id, of each entrant.
 <!--Request-->
 
 ```graphql
-query PoolSeeds($phaseGroupId: Int) {
+query PoolSeeds($phaseGroupId: Int!) {
   phaseGroup(id: $phaseGroupId) {
     seeds {
       id

--- a/docs/examples/recent-sets-by-player.md
+++ b/docs/examples/recent-sets-by-player.md
@@ -14,10 +14,13 @@ You can read a deeper explanation of this topic in our
  <a href="https://help.smash.gg/attendee-management/attendee-confirmation/attendee-confirmation-requests-overview"
  target="_blank">help center articles on attendee confirmation</a>.
 
-## Example #1 Request (not Specifying Opponent)
+## Example #1 (not Specifying Opponent)
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Request-->
 
 ```GraphQL
-query setsByPlayer($playerId: Int!) {
+query SetsByPlayer($playerId: Int!) {
   player(id: $playerId) {
     id
     gamerTag
@@ -33,18 +36,13 @@ query setsByPlayer($playerId: Int!) {
       displayScore
     }
   }
-}
-```
-
-Request Variables
-
-```json
+},
 {
   "playerId": 148649
 }
 ```
 
-## Request #1 Response
+<!--Response-->
 
 ```json
 {
@@ -170,10 +168,15 @@ Request Variables
 }
 ```
 
-## Example #2 Request (Specifying Opponent Player)
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+## Example #2 (Specifying Opponent Player)
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Request-->
 
 ```GraphQL
-query setsByPlayer($playerId: Int!, $oppPlayerId: Int!) {
+query SetsByPlayerAndOpponent($playerId: Int!, $oppPlayerId: Int!) {
   player(id: $playerId) {
     id
     gamerTag
@@ -189,19 +192,14 @@ query setsByPlayer($playerId: Int!, $oppPlayerId: Int!) {
       displayScore
     }
   }
-}
-```
-
-Request Variables
-
-```json
+},
 {
   "playerId": 1016,
   "oppPlayerId": 1017
 }
 ```
 
-## Example #2 Response
+<!--Response-->
 
 ```json
 {
@@ -282,3 +280,5 @@ Request Variables
   "actionRecords": []
 }
 ```
+
+<!--END_DOCUSAURUS_CODE_TABS-->

--- a/docs/examples/set-entrants.md
+++ b/docs/examples/set-entrants.md
@@ -8,7 +8,10 @@ a 3v3 Rocket League event.
 In a teams event, an entrant has multiple participants,
 so we will get the available fields for each of those, too!
 
-## Example Request
+## Example
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Request-->
 
 ```graphql
 query SetEntrants($setId: String!) {
@@ -27,18 +30,13 @@ query SetEntrants($setId: String!) {
       }
     }
   }
-}
-```
-
-Request Variables
-
-```json
+},
 {
   "setId": "7851789"
 }
 ```
 
-## Example Response
+<!--Response-->
 
 ```json
 {
@@ -130,3 +128,5 @@ Request Variables
   "actionRecords": []
 }
 ```
+
+<!--END_DOCUSAURUS_CODE_TABS-->

--- a/docs/examples/stream-queue.md
+++ b/docs/examples/stream-queue.md
@@ -32,7 +32,7 @@ query StreamQueueOnTournament($tourneySlug:String!){
 ```
 
 You can request other fields on sets, and there are also
- some other sets on stream that you can request.
+ some other fields on stream that you can request.
 Check the schema for what's available!
 
 <!--Response-->

--- a/docs/examples/stream-queue.md
+++ b/docs/examples/stream-queue.md
@@ -9,7 +9,7 @@ In this example we will get a stream queue on a given tournament, including:
 - Information about the sets for each stream
 
 <!--DOCUSAURUS_CODE_TABS-->
-<!--Example Request-->
+<!--Request-->
 
 ```graphQL
 query StreamQueueOnTournament($tourneySlug:String!){
@@ -35,7 +35,7 @@ You can request other fields on sets, and there are also
  some other sets on stream that you can request.
 Check the schema for what's available!
 
-<!--Example Response-->
+<!--Response-->
 
 ```json
 {
@@ -165,6 +165,4 @@ Check the schema for what's available!
 
 In the response, the sets are ordered top-to-bottom as first-to-last in the queue.
 
-
 <!--END_DOCUSAURUS_CODE_TABS-->
-

--- a/docs/examples/tournaments-by-location.md
+++ b/docs/examples/tournaments-by-location.md
@@ -11,7 +11,7 @@ In these examples, we will query for tournaments in a given location!
 <!--Request-->
 
 ```graphql
-query TournamentsByCountry($cCode: String!, $perPage: Int) {
+query TournamentsByCountry($cCode: String!, $perPage: Int!) {
   tournaments(query: {
     perPage: $perPage
     filter: {

--- a/docs/examples/tournaments-by-location.md
+++ b/docs/examples/tournaments-by-location.md
@@ -5,7 +5,10 @@ title: Tournaments by Location
 
 In these examples, we will query for tournaments in a given location!
 
-## Example #1 Request (by Country)
+## Example #1 (by Country)
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Request-->
 
 ```graphql
 query TournamentsByCountry($cCode: String!, $perPage: Int) {
@@ -21,19 +24,14 @@ query TournamentsByCountry($cCode: String!, $perPage: Int) {
       countryCode
     }
   }
-}
-```
-
-Request Variables
-
-```json
+},
 {
   "cCode": "JP",
   "perPage": 4
 }
 ```
 
-## Example #1 Response
+<!--Response-->
 
 ```json
 {
@@ -67,7 +65,16 @@ Request Variables
 }
 ```
 
-## Example #2 Request (by State)
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+## Example #2 (by State)
+
+To be clear, 'State' in this context means like 'United States' like California, Georgia, etc.
+State abbreviations can be found on external sites like this
+ [UPS resource](https://www.ups.com/worldshiphelp/WS15/ENU/AppHelp/Codes/State_Province_Codes.htm).
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Request-->
 
 ```graphql
 query TournamentsByState($perPage: Int, $state: String!) {
@@ -83,19 +90,14 @@ query TournamentsByState($perPage: Int, $state: String!) {
       addrState
     }
   }
-}
-```
-
-Request Variables
-
-```json
+},
 {
   "perPage": 4,
   "state": "CT"
 }
 ```
 
-## Example #2 Response
+<!--Response-->
 
 ```json
 {
@@ -129,7 +131,12 @@ Request Variables
 }
 ```
 
-## Example #3 Request (by coordinates + radius distance)
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+## Example #3 (by coordinates + radius distance)
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Request-->
 
 ```graphql
 query SocalTournaments($perPage: Int, $coordinates: String!, $radius: String!) {
@@ -148,12 +155,7 @@ query SocalTournaments($perPage: Int, $coordinates: String!, $radius: String!) {
       city
     }
   }
-}
-```
-
-Request variables
-
-```json
+},
 {
   "perPage": 4,
   "coordinates": "33.7454725,-117.86765300000002",
@@ -161,7 +163,7 @@ Request variables
 }
 ```
 
-## Example #3 Response
+<!--Response-->
 
 ```json
 {
@@ -194,3 +196,5 @@ Request variables
   "actionRecords": []
 }
 ```
+
+<!--END_DOCUSAURUS_CODE_TABS-->

--- a/docs/examples/tournaments-by-owner.md
+++ b/docs/examples/tournaments-by-owner.md
@@ -7,7 +7,10 @@ In this example, we will query for upcoming tournaments filtered to particular o
 Please note that this query will not retrieve all tournaments the user was an admin for.
 It will only return tournaments which that user created.
 
-## Example #1 Request
+## Example
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Request-->
 
 ```graphql
 query TournamentsByowner($perPage: Int, $ownerId: Int) {
@@ -23,19 +26,14 @@ query TournamentsByowner($perPage: Int, $ownerId: Int) {
       slug
     }
   }
-}
-```
-
-Query Variables
-
-```json
+},
 {
   "ownerId": 161429,
   "perPage": 4
 }
 ```
 
-## Example #1 Response
+<!--Response-->
 
 ```json
 {
@@ -68,3 +66,5 @@ Query Variables
   "actionRecords": []
 }
 ```
+
+<!--END_DOCUSAURUS_CODE_TABS-->

--- a/docs/examples/tournaments-by-owner.md
+++ b/docs/examples/tournaments-by-owner.md
@@ -13,7 +13,7 @@ It will only return tournaments which that user created.
 <!--Request-->
 
 ```graphql
-query TournamentsByowner($perPage: Int, $ownerId: Int) {
+query TournamentsByowner($perPage: Int!, $ownerId: Int!) {
     tournaments(query: {
       perPage: $perPage
       filter: {

--- a/docs/examples/tournaments-by-videogame.md
+++ b/docs/examples/tournaments-by-videogame.md
@@ -10,7 +10,10 @@ and the second example will be for an array of videogames.
 
 For now, you can view the mapping of videogame IDs to their names <a href="https://docs.google.com/spreadsheets/d/1Iq-gueeLYeoVbf1oxVzh5942rX9RG8E6Wxn-yhSbvbQ/edit?usp=sharing" target="_blank">in this sheet here.</a>
 
-## Example #1 Request (single videogame)
+## Example #1 (Single Videogame)
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Request-->
 
 ```graphql
 query TournamentsByVideogame($perPage: Int, $videogameId: Int) {
@@ -31,19 +34,14 @@ query TournamentsByVideogame($perPage: Int, $videogameId: Int) {
       slug
     }
   }
-}
-```
-
-Query Variables
-
-```json
+},
 {
   "perPage": 3,
   "videogameId": 287
 }
 ```
 
-## Example #1 Response
+<!--Response-->
 
 ```json
 {
@@ -72,7 +70,12 @@ Query Variables
 }
 ```
 
-## Example #2 Request (array of videogames)
+<!--END_DOCUSAURUS_CODE_TABS-->
+
+## Example #2 (Array of Videogames)
+
+<!--DOCUSAURUS_CODE_TABS-->
+<!--Request-->
 
 ```graphql
 query TournamentsByVideogames($perPage: Int, $videogameIds: [Int]) {
@@ -91,19 +94,14 @@ query TournamentsByVideogames($perPage: Int, $videogameIds: [Int]) {
       slug
     }
   }
-}
-```
-
-Query Variables
-
-```json
+},
 {
   "perPage": 3,
   "videogameIds": [15, 24]
 }
 ```
 
-## Example #2 Response
+<!--Response-->
 
 ```json
 {
@@ -131,3 +129,5 @@ Query Variables
   "actionRecords": []
 }
 ```
+
+<!--END_DOCUSAURUS_CODE_TABS-->

--- a/docs/examples/tournaments-by-videogame.md
+++ b/docs/examples/tournaments-by-videogame.md
@@ -16,7 +16,7 @@ For now, you can view the mapping of videogame IDs to their names <a href="https
 <!--Request-->
 
 ```graphql
-query TournamentsByVideogame($perPage: Int, $videogameId: Int) {
+query TournamentsByVideogame($perPage: Int!, $videogameId: Int!) {
   tournaments(query: {
     perPage: $perPage
     page: 1

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -11,10 +11,10 @@
 			"benefits-of-gql"			
 		],
     "Example Usage": [
+			"examples/event-standings",
 			"examples/recent-sets-by-player",
 			"examples/stream-queue",
 			"examples/set-entrants",
-			"examples/event-standings",
 			"examples/pool-seeds",
 			"examples/attendee-counts",
 			"examples/tournaments-by-location",


### PR DESCRIPTION
Now all example docs (for queries, not mutations yet) use Code Tabs