### PR TITLE
Changed the GraphQL queries in the examples to be in line

### DIFF
--- a/docs/examples/queries/attendee-counts.md
+++ b/docs/examples/queries/attendee-counts.md
@@ -13,11 +13,11 @@ Optionally, we can include an array of eventIds to specify a count for a particu
 <!--Request-->
 
 ```GraphQL
-query AttendeeCount($tourneySlug:String!){
-  tournament(slug:$tourneySlug){
+query AttendeeCount($tourneySlug:String!) {
+  tournament(slug:$tourneySlug) {
     name
-    participants(query:{}){
-      pageInfo{
+    participants(query: {}) {
+      pageInfo {
         total
       }
     }
@@ -53,15 +53,15 @@ query AttendeeCount($tourneySlug:String!){
 <!--Request-->
 
 ```GraphQL
-query AttendeeCount($tourneySlug:String!, $eventIds:[ID]){
-  tournament(slug:$tourneySlug){
+query AttendeeCount($tourneySlug: String!, $eventIds: [ID]) {
+  tournament(slug: $tourneySlug) {
     name
-    participants(query:{
-      filter:{
+    participants(query: {
+      filter: {
         eventIds:$eventIds
       }
-    }){
-      pageInfo{
+    }) {
+      pageInfo {
         total
       }
     }

--- a/docs/examples/queries/count-entrants-by-event.md
+++ b/docs/examples/queries/count-entrants-by-event.md
@@ -18,7 +18,7 @@ You can also use that number to count the total number of players who competed i
 
 ```graphql
 query CountEntrants($eventId: ID!) {
-  event(id:$eventId) {
+  event(id: $eventId) {
     id
     name
     numEntrants
@@ -54,7 +54,7 @@ query CountEntrants($eventId: ID!) {
 
 ```graphql
 query CountEntrants($eventId: ID!) {
-  event(id:$eventId) {
+  event(id: $eventId) {
     id
     name
     numEntrants

--- a/docs/examples/queries/event-entrants.md
+++ b/docs/examples/queries/event-entrants.md
@@ -14,12 +14,12 @@ This is a paginated query- I chose a small `perPage` value for the sake of space
 <!--Request-->
 
 ```GraphQL
-query EventEntrants($eventId: ID!,$page:Int!,$perPage:Int!){
-  event(id:$eventId){
+query EventEntrants($eventId: ID!, $page: Int!, $perPage: Int!) {
+  event(id: $eventId) {
     name
-    entrants(query:{
-      page:$page
-      perPage:$perPage
+    entrants(query: {
+      page: $page
+      perPage: $perPage
     }){
       pageInfo{
         total

--- a/docs/examples/queries/event-standings.md
+++ b/docs/examples/queries/event-standings.md
@@ -92,7 +92,7 @@ If you don't know what race format is, then don't worry about this!
 
 ```graphql
 query EventStandings($eventId: ID!) {
-  event(id:$eventId) {
+  event(id: $eventId) {
     id
     name
     phaseGroups {

--- a/docs/examples/queries/phase-groups-in-phase.md
+++ b/docs/examples/queries/phase-groups-in-phase.md
@@ -10,16 +10,16 @@ I have decided to query for the phase groups in the "R1 Pools" Phase of Genesis 
 <!--Request-->
 
 ```gql
-query PhaseGroupsByPhase($phaseId: ID!,$page:Int!,$perPage:Int!){
-  phase(id:$phaseId){
+query PhaseGroupsByPhase($phaseId: ID!, $page: Int!, $perPage: Int!) {
+  phase(id: $phaseId) {
     phaseGroups(query: {
-      page:$page
-      perPage:$perPage
+      page: $page
+      perPage: $perPage
     }) {
-      pageInfo{
+      pageInfo {
         total
       }
-      nodes{
+      nodes {
         id
         displayIdentifier
       }

--- a/docs/examples/queries/phase-seeds.md
+++ b/docs/examples/queries/phase-seeds.md
@@ -14,21 +14,21 @@ To adjust phase seeding, please see
 <!--Request-->
 
 ```GraphQL
-query PhaseSeeds($phaseId: ID!,$page:Int!,$perPage:Int!){
-  phase(id:$phaseId){
-    seeds(query:{
-      page:$page
-      perPage:$perPage
+query PhaseSeeds($phaseId: ID!, $page: Int!, $perPage: Int!) {
+  phase(id:$phaseId) {
+    seeds(query: {
+      page: $page
+      perPage: $perPage
     }){
-      pageInfo{
+      pageInfo {
         total
         totalPages
       }
-      nodes{
+      nodes {
         id
         seedNum
-        entrant{
-          participants{
+        entrant {
+          participants {
             gamerTag
           }
         }
@@ -98,22 +98,22 @@ The participants for the entrant will include all players on the roster.
 <!--Request-->
 
 ```GraphQL
-query PhaseSeeds($phaseId: ID!,$page:Int!,$perPage:Int!){
-  phase(id:$phaseId){
-    seeds(query:{
-      page:$page
-      perPage:$perPage
-    }){
-      pageInfo{
+query PhaseSeeds($phaseId: ID!, $page: Int!, $perPage: Int!) {
+  phase(id: $phaseId) {
+    seeds(query: {
+      page: $page
+      perPage: $perPage
+    }) {
+      pageInfo {
         total
         totalPages
       }
-      nodes{
+      nodes {
         id
         seedNum
-        entrant{
+        entrant {
           name
-          participants{
+          participants {
             gamerTag
           }
         }

--- a/docs/examples/queries/pool-seeds.md
+++ b/docs/examples/queries/pool-seeds.md
@@ -16,14 +16,14 @@ We'll include the name, and the seed id, of each entrant.
 query PoolSeeds($phaseGroupId: ID!, $page: Int!, $perPage: Int!) {
   phaseGroup(id: $phaseGroupId) {
     id
-    seeds(query:{
+    seeds(query: {
       page: $page
       perPage: $perPage
     }){
-      pageInfo{
+      pageInfo {
         total
       }
-      nodes{
+      nodes {
         entrant {
         id
         name

--- a/docs/examples/queries/recent-sets-by-player.md
+++ b/docs/examples/queries/recent-sets-by-player.md
@@ -24,12 +24,12 @@ query SetsByPlayer($playerId: ID!) {
   player(id: $playerId) {
     id
     gamerTag
-    recentSets{
+    recentSets {
       id
       phaseGroupId
-      event{
+      event {
         name
-        tournament{
+        tournament {
           name
         }
       }
@@ -180,12 +180,12 @@ query SetsByPlayerAndOpponent($playerId: ID!, $oppPlayerId: ID!) {
   player(id: $playerId) {
     id
     gamerTag
-    recentSets(opponentId: $oppPlayerId){
+    recentSets(opponentId: $oppPlayerId) {
       id
       phaseGroupId
-      event{
+      event {
         name
-        tournament{
+        tournament {
           name
         }
       }

--- a/docs/examples/queries/set-score.md
+++ b/docs/examples/queries/set-score.md
@@ -15,13 +15,13 @@ For this completed head-to-head set, one entrant won (ie their placement is '1')
 <!--Request-->
 
 ```GraphQL
-query set($setId: ID!){
-  set(id:$setId){
+query set($setId: ID!) {
+  set(id: $setId) {
     id
-    slots{
-      standing{
+    slots {
+      standing {
         placement
-        stats{
+        stats {
           score {
             label
             value
@@ -81,16 +81,16 @@ query set($setId: ID!){
 <!--Request-->
 
 ```GraphQL
-query InProgressSet{
-  set(id:"18273807"){
+query InProgressSet {
+  set(id: "18273807") {
     state
-    slots{
-      entrant{
+    slots {
+      entrant {
         name
       }
-      standing{
-        stats{
-          score{
+      standing {
+        stats {
+          score {
             value
           }
         }

--- a/docs/examples/queries/sets-by-station.md
+++ b/docs/examples/queries/sets-by-station.md
@@ -17,22 +17,22 @@ You can use a much larger `perPage` here- it is kept small in the example for de
 <!--Request-->
 
 ```GraphQL
-query SetsAtStation($eventId:ID!,$stationNumbers:[Int]){
-  event(id: $eventId){
+query SetsAtStation($eventId: ID!, $stationNumbers: [Int]) {
+  event(id: $eventId) {
     name
     sets(
       page: 1
       perPage: 3
       filters: {
       stationNumbers: $stationNumbers
-    }){
-      nodes{
+    }) {
+      nodes {
         id
-        station{
+        station {
           number
         }
-        slots{
-          entrant{
+        slots {
+          entrant {
             name
           }
         }

--- a/docs/examples/queries/sets-in-event.md
+++ b/docs/examples/queries/sets-in-event.md
@@ -16,23 +16,23 @@ You can use a much larger `perPage` here- it is kept small in the example for de
 <!--Request-->
 
 ```GraphQL
-query EventSets($eventId: ID!, $page:Int!, $perPage:Int!){
-  event(id:$eventId){
+query EventSets($eventId: ID!, $page: Int!, $perPage: Int!) {
+  event(id: $eventId) {
     id
     name
     sets(
       page: $page
       perPage: $perPage
       sortType: STANDARD
-    ){
-      pageInfo{
+    ) {
+      pageInfo {
         total
       }
-      nodes{
+      nodes {
         id
-        slots{
+        slots {
           id
-          entrant{
+          entrant {
             id
             name
           }

--- a/docs/examples/queries/sets-in-phase.md
+++ b/docs/examples/queries/sets-in-phase.md
@@ -16,8 +16,8 @@ You can use a much larger `perPage` here- it is kept small in the example for de
 <!--Request-->
 
 ```GraphQL
-query PhaseSets($phaseId: ID!, $page:Int!, $perPage:Int!){
-  phase(id:$phaseId){
+query PhaseSets($phaseId: ID!, $page: Int!, $perPage: Int!) {
+  phase(id: $phaseId) {
     id
     name
     sets(
@@ -25,14 +25,14 @@ query PhaseSets($phaseId: ID!, $page:Int!, $perPage:Int!){
       perPage: $perPage
       sortType: STANDARD
     ){
-      pageInfo{
+      pageInfo {
         total
       }
-      nodes{
+      nodes {
         id
-        slots{
+        slots {
           id
-          entrant{
+          entrant {
             id
             name
           }

--- a/docs/examples/queries/shop.md
+++ b/docs/examples/queries/shop.md
@@ -19,7 +19,7 @@ query Shop ($slug: String) {
     id
     name
     slug
-    messages(query:{
+    messages(query: {
         page:1
         perPage:5
     }) {
@@ -30,10 +30,10 @@ query Shop ($slug: String) {
         name
       }
     }
-    levels(query:{
+    levels(query: {
         page:1
         perPage:5
-	}) {
+    }) {
       nodes {
         name
         goalAmount

--- a/docs/examples/queries/stream-queue.md
+++ b/docs/examples/queries/stream-queue.md
@@ -12,15 +12,15 @@ In this example we will get a stream queue on a given tournament, including:
 <!--Request-->
 
 ```graphQL
-query StreamQueueOnTournament($tourneySlug:String!){
-  tournament(slug:$tourneySlug){
+query StreamQueueOnTournament($tourneySlug: String!) {
+  tournament(slug: $tourneySlug) {
     id
-    streamQueue{
-      stream{
+    streamQueue {
+      stream {
         streamSource
         streamName
       }
-      sets{
+      sets {
         id
       }
     }

--- a/docs/examples/queries/tournaments-by-owner.md
+++ b/docs/examples/queries/tournaments-by-owner.md
@@ -13,7 +13,7 @@ It will only return tournaments which that user created.
 <!--Request-->
 
 ```graphql
-query TournamentsByowner($perPage: Int!, $ownerId: ID!) {
+query TournamentsByOwner($perPage: Int!, $ownerId: ID!) {
     tournaments(query: {
       perPage: $perPage
       filter: {


### PR DESCRIPTION
- Changed all GraphQL queries in the examples to be uniform.


---

Was looking over the repo and saw that all the format for the examples was quite random. I streamlined them all in one commit, less OCD will be triggered today.