### PR TITLE
feat(website): add DocSearch as recommended by docusaurus.

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -110,6 +110,10 @@ module.exports = {
       trackingID: 'UA-58622313-9',
     },
   },
+  algolia: {
+    apiKey: '36e9b03106508b49af23386dd55c92c3',
+    indexName: 'developer-portal',
+  },
   presets: [
     [
       '@docusaurus/preset-classic',


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.