### PR TITLE
feat(website): add DocSearch as recommended by docusaurus

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -2,6 +2,10 @@
 const repoUrl = 'https://github.com/smashgg/developer-portal';
 
 module.exports = {
+    algolia: {
+    apiKey: '89c46064287024ef645cdfe67ff077ca',
+    indexName: 'smash',
+  },
   title: 'Developer Portal',
   tagline: 'Turning passions into careers',
   url: 'https://developer.smash.gg',


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.