### PR TITLE
Fix broken sort examples

### DIFF
--- a/docs/examples/queries/tournaments-by-videogame.md
+++ b/docs/examples/queries/tournaments-by-videogame.md
@@ -29,7 +29,7 @@ query TournamentsByVideogame($perPage: Int!, $videogameId: ID!) {
   tournaments(query: {
     perPage: $perPage
     page: 1
-    sortBy: "startAt asc"
+    sortBy: "tournament.startAt asc"
     filter: {
       past: false
       videogameIds: [
@@ -100,7 +100,7 @@ query TournamentsByVideogames($perPage: Int, $videogameIds: [ID]) {
   tournaments(query: {
     perPage: $perPage
     page: 1
-    sortBy: "startAt asc"
+    sortBy: "tournament.startAt asc"
     filter: {
       upcoming: true
       videogameIds: $videogameIds


### PR DESCRIPTION
These examples would previously cause an internal server error. These are now fixed and work as expected.