### PR TITLE
Added Get Event as an example query

### DIFF
--- a/docs/examples/queries/get-event.md
+++ b/docs/examples/queries/get-event.md
@@ -6,7 +6,7 @@ title: Get Event
 In this example, we will query the Smash Ultimate Singles event at Genesis 9.
 An **Event ID** is necessary if you want to get information specific to a tournament event.
 To do so, we make use of a string of characters called **slug**, easily obtainable from
-the URL of the tournament event page in [start.gg](https://www.start.gg/).
+the URL of the tournament event page in <a href="https://www.start.gg/" target="_blank">start.gg</a>.
 
 Go to the tournament page and select the event:
 

--- a/docs/examples/queries/get-event.md
+++ b/docs/examples/queries/get-event.md
@@ -10,11 +10,11 @@ the URL of the tournament event page in [start.gg](https://www.start.gg/).
 
 Go to the tournament page and select the event:
 
-![image](https://imgur.com/a/8jhfgxs)
+![image](https://imgur.com/a/8jhfgxs.png)
 
 Now that you selected it, you can find the slug inside of the URL of the page:
 
-![image](https://imgur.com/a/pzHl9OK)
+![image](https://imgur.com/a/pzHl9OK.png)
 
 A slug is made of two parts, the tournament name and the event name.
 The format is this: `tournament/<tournament_name>/event/<event_name>`.

--- a/docs/examples/queries/get-event.md
+++ b/docs/examples/queries/get-event.md
@@ -12,7 +12,7 @@ Go to the tournament page and select the event:
 
 ![image](https://imgur.com/11pYReL.png)
 
-Now that you selected it, you can find the slug inside of the URL of the page:
+Now that you selected it, you can find the slug inside  the URL of the page:
 
 ![image2](https://imgur.com/O58anju.png)
 

--- a/docs/examples/queries/get-event.md
+++ b/docs/examples/queries/get-event.md
@@ -1,0 +1,94 @@
+---
+id: get-event
+title: Get Event
+---
+
+In this example, we will query the Smash Ultimate Singles event at Genesis 9.
+An **Event ID** is necessary if you want to get information specific to a tournament event.
+To do so, we make use of a string of characters called **slug**, easily obtainable from
+the URL of the tournament event page in [start.gg](https://www.start.gg/).
+
+Go to the tournament page and select the event:
+
+![image](https://imgur.com/a/8jhfgxs)
+
+Now that you selected it, you can find the slug inside of the URL of the page:
+
+![image](https://imgur.com/a/pzHl9OK)
+
+A slug is made of two parts: the tournament name and the event name.
+The format is this: `tournament/<tournament_name>/event/<event_name>`.
+In this case, the slug we're going to use is `tournament/genesis-9-1/event/ultimate-singles`.
+
+Now that we have the slug, we can use it as a variable in the following query:
+
+## Example
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs
+defaultValue="graphql"
+values={[
+{ label: 'Request', value: 'graphql', },
+{ label: 'Response', value: 'json', },
+]
+}>
+<TabItem value="graphql">
+
+```graphql
+query getEventId($slug: String) {
+  event(slug: $slug) {
+    id
+    name
+  }
+},
+{
+  "slug": "tournament/genesis-9-1/event/ultimate-singles"
+}
+```
+
+</TabItem>
+
+<TabItem value="json">
+
+```json
+{
+  "data": {
+    "event": {
+      "id": 769488,
+      "name": "Ultimate Singles"
+    }
+  },
+  "extensions": {
+    "cacheControl": {
+      "version": 1,
+      "hints": [
+        {
+          "path": [
+            "event"
+          ],
+          "maxAge": 60,
+          "scope": "PRIVATE"
+        }
+      ]
+    },
+    "queryComplexity": 1
+  },
+  "actionRecords": []
+}
+```
+
+</TabItem>
+</Tabs>
+
+If you go in the Response tab, you will find two useful pieces of information under event:
+
+- _id_ is the Event ID of the tournament event
+- _name_ is the name of the tournament event
+
+Now that you have the Event ID, you can use it for many more queries.
+For example you can search for [Event Standings](/docs/examples/queries/event-standings) or [Event Entrants](/docs/examples/queries/event-entrants).
+
+**Don't forget to explore schema, and test queries, in the [API Explorer](/explorer)!**
+

--- a/docs/examples/queries/get-event.md
+++ b/docs/examples/queries/get-event.md
@@ -82,7 +82,7 @@ query getEventId($slug: String) {
 </TabItem>
 </Tabs>
 
-If you go in the Response tab, you will find two useful pieces of information under event:
+If you go in the *Response* tab, you will find two useful pieces of information under event:
 
 - _id_ is the Event ID of the tournament event
 - _name_ is the name of the tournament event

--- a/docs/examples/queries/get-event.md
+++ b/docs/examples/queries/get-event.md
@@ -10,11 +10,11 @@ the URL of the tournament event page in [start.gg](https://www.start.gg/).
 
 Go to the tournament page and select the event:
 
-![image](https://imgur.com/a/8jhfgxs.png)
+![image](https://imgur.com/11pYReL.png)
 
 Now that you selected it, you can find the slug inside of the URL of the page:
 
-![image](https://imgur.com/a/pzHl9OK.png)
+![image2](https://imgur.com/O58anju.png)
 
 A slug is made of two parts, the tournament name and the event name.
 The format is this: `tournament/<tournament_name>/event/<event_name>`.

--- a/docs/examples/queries/get-event.md
+++ b/docs/examples/queries/get-event.md
@@ -16,7 +16,7 @@ Now that you selected it, you can find the slug inside of the URL of the page:
 
 ![image](https://imgur.com/a/pzHl9OK)
 
-A slug is made of two parts: the tournament name and the event name.
+A slug is made of two parts, the tournament name and the event name.
 The format is this: `tournament/<tournament_name>/event/<event_name>`.
 In this case, the slug we're going to use is `tournament/genesis-9-1/event/ultimate-singles`.
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,55 +1,56 @@
 {
-	"docs": {
-		"Getting Started": [
-			"intro",
-			"join-discord",
-			"glossary",
-			"intro-to-gql",
-			"authentication",
-			"testing-your-requests",
-			"sending-requests",
-			"rate-limits",
-			"benefits-of-gql"
-		],
-		"Query Examples": [
-			"examples/queries/event-standings",
-			"examples/queries/event-entrants",
-			"examples/queries/league-schedule",
-			"examples/queries/league-standings",
-			"examples/queries/sets-in-event",
-			"examples/queries/sets-in-phase",
-			"examples/queries/sets-in-phase-group",
-			"examples/queries/sets-by-station",
-			"examples/queries/set-score",
-			"examples/queries/sets-by-player",
-			"examples/queries/stream-queue",
-			"examples/queries/set-entrants",
-			"examples/queries/phase-groups-in-phase",
-			"examples/queries/get-phase-seeding",
-			"examples/queries/pool-seeds",
-			"examples/queries/attendee-counts",
-			"examples/queries/tournaments-by-location",
-			"examples/queries/tournaments-by-videogame",
-			"examples/queries/tournaments-by-owner",
-			"examples/queries/attendees-by-sponsor",
-			"examples/queries/videogame-id-by-name",
-			"examples/queries/shop"
-		],
-		"Mutation Examples": [
-			"examples/mutations/report-set"
-		],
-		"Widgets & Embeds": [
-			"widgets/registration"
-		],
-		"Full Examples": [
-			"e2e/update-phase-seeding",
-			"e2e/resolve-conflicts",
-			"e2e/randomize-phase-seeding"
-		],
-		"OAuth": [
-			"oauth/oauth-overview",
-			"oauth/scopes",
-			"oauth/example-oauth-flow"
-		]
-	}
+  "docs": {
+    "Getting Started": [
+      "intro",
+      "join-discord",
+      "glossary",
+      "intro-to-gql",
+      "authentication",
+      "testing-your-requests",
+      "sending-requests",
+      "rate-limits",
+      "benefits-of-gql"
+    ],
+    "Query Examples": [
+      "examples/queries/get-event",
+      "examples/queries/event-standings",
+      "examples/queries/event-entrants",
+      "examples/queries/league-schedule",
+      "examples/queries/league-standings",
+      "examples/queries/sets-in-event",
+      "examples/queries/sets-in-phase",
+      "examples/queries/sets-in-phase-group",
+      "examples/queries/sets-by-station",
+      "examples/queries/set-score",
+      "examples/queries/sets-by-player",
+      "examples/queries/stream-queue",
+      "examples/queries/set-entrants",
+      "examples/queries/phase-groups-in-phase",
+      "examples/queries/get-phase-seeding",
+      "examples/queries/pool-seeds",
+      "examples/queries/attendee-counts",
+      "examples/queries/tournaments-by-location",
+      "examples/queries/tournaments-by-videogame",
+      "examples/queries/tournaments-by-owner",
+      "examples/queries/attendees-by-sponsor",
+      "examples/queries/videogame-id-by-name",
+      "examples/queries/shop"
+    ],
+    "Mutation Examples": [
+      "examples/mutations/report-set"
+    ],
+    "Widgets & Embeds": [
+      "widgets/registration"
+    ],
+    "Full Examples": [
+      "e2e/update-phase-seeding",
+      "e2e/resolve-conflicts",
+      "e2e/randomize-phase-seeding"
+    ],
+    "OAuth": [
+      "oauth/oauth-overview",
+      "oauth/scopes",
+      "oauth/example-oauth-flow"
+    ]
+  }
 }


### PR DESCRIPTION
Hello!

I just started using the start.gg API and I noticed there wasn't an example to get the Event Id, which is necessary for many other queries, so I decided to write down a simple starting guide for it. Here's the changes:

- Added new file 'get-event'
- modified sidebars.json 

I put the new page 'get-event' as the first one in the Query Examples directory since the Event Id can be used for the examples just after it.

I also tried to follow the guidelines as much as possible, thanks for the consideration!