### PR TITLE
Update users.js with Start Predict project

### DIFF
--- a/website/data/users.js
+++ b/website/data/users.js
@@ -45,6 +45,13 @@ const users = [
     pinned: true,
   },
   {
+  caption: 'Start Predict',
+  image: 'https://i.imgur.com/3t3xGNC.png',  
+  infoLink: 'https://startpredict.com',  
+  openSource: false,  
+  pinned: true, 
+},
+  {
     caption: 'SmashTicker',
     image:
       'https://lh3.googleusercontent.com/HJzDy4IhHwwpmb_LZtYs4tmth-Z4N8BYltaxBlgMjkIaB97HIer3HJY3V6Ebh39dKn2s0qGRGuo=w128-h128-e365',


### PR DESCRIPTION
Start Predict is a project that integrates data from start.gg, allowing users to make predictions for any tournament. It offers pre- and post-match statistics, provides insights into results, and even enables users to download their predictions. With a range of features designed for in-depth analysis, it enhances the tournament experience for competitive gamers.