### PR TITLE
Missing space in the Help page

### DIFF
--- a/website/src/pages/help.js
+++ b/website/src/pages/help.js
@@ -28,8 +28,7 @@ function Help() {
     {
       content: (
         <>
-          Learn more about using the start.gg public API in our 
-          <Link to="docs/intro">official documentation</Link>
+          Learn more about using the start.gg public API in our <Link to="docs/intro">official documentation</Link>
         </>
       ),
       title: 'Browse Docs',


### PR DESCRIPTION
This is the smallest PR I've ever done, as it adds a single space, that was missing on [this page](https://developer.start.gg/help)