### PR TITLE
Add Brackify project details to users.js

### DIFF
--- a/website/data/users.js
+++ b/website/data/users.js
@@ -9,6 +9,13 @@ const users = [
     pinned: true,
   },
   {
+  caption: 'Brackify',
+  image: 'https://res.cloudinary.com/dfeedwjpf/image/upload/v1766971621/logo_b6puil.png',
+  infoLink: 'https://brackify.gg',
+  openSource: false,
+  pinned: true,
+},
+  {
     caption: 'Brawlhalla Matchups',
     image: 'https://imgur.com/rO1rrqv.png',
     infoLink: 'https://github.com/henryaguerra/brawlhalla-matchups-bot',

--- a/website/data/users.js
+++ b/website/data/users.js
@@ -11,7 +11,7 @@ const users = [
   {
   caption: 'Brackify',
   image: 'https://res.cloudinary.com/dfeedwjpf/image/upload/v1766971621/logo_b6puil.png',
-  infoLink: 'https://brackify.gg',
+  infoLink: 'https://brackify.gg/app',
   openSource: false,
   pinned: true,
 },


### PR DESCRIPTION
Adds Brackify to the Developer Portal Users page with logo and project link.